### PR TITLE
`bus_env.bus_regs` enhancements + some examples of abstract methods

### DIFF
--- a/bus_env/bus_agent/bus_apb_monitor.py
+++ b/bus_env/bus_agent/bus_apb_monitor.py
@@ -3,9 +3,6 @@ from uvm.comps.uvm_monitor import UVMMonitor
 from uvm.tlm1.uvm_analysis_port import UVMAnalysisPort
 from uvm.base.uvm_config_db import UVMConfigDb
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from uvm.base.uvm_object_globals import UVM_HIGH
-from EF_UVM.bus_env.bus_item import bus_item
-from EF_UVM.bus_env.bus_agent.bus_base_monitor import bus_base_monitor
 from EF_UVM.bus_env.bus_item import bus_item
 from uvm.base.uvm_object_globals import UVM_HIGH, UVM_LOW
 from EF_UVM.bus_env.bus_agent.bus_base_monitor import bus_base_monitor

--- a/bus_env/bus_agent/bus_apb_monitor.py
+++ b/bus_env/bus_agent/bus_apb_monitor.py
@@ -3,10 +3,12 @@ from uvm.comps.uvm_monitor import UVMMonitor
 from uvm.tlm1.uvm_analysis_port import UVMAnalysisPort
 from uvm.base.uvm_config_db import UVMConfigDb
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from uvm.base.uvm_object_globals import UVM_HIGH, UVM_LOW
+from uvm.base.uvm_object_globals import UVM_HIGH
 from EF_UVM.bus_env.bus_item import bus_item
 from EF_UVM.bus_env.bus_agent.bus_base_monitor import bus_base_monitor
-
+from EF_UVM.bus_env.bus_item import bus_item
+from uvm.base.uvm_object_globals import UVM_HIGH, UVM_LOW
+from EF_UVM.bus_env.bus_agent.bus_base_monitor import bus_base_monitor
 import cocotb
 
 

--- a/bus_env/bus_seq_lib/bus_seq_base.py
+++ b/bus_env/bus_seq_lib/bus_seq_base.py
@@ -8,7 +8,6 @@ from uvm.base.uvm_object_globals import UVM_HIGH, UVM_LOW, UVM_MEDIUM
 
 
 class bus_seq_base(UVMSequence):
-
     def __init__(self, name="bus_seq_base"):
         UVMSequence.__init__(self, name)
         self.set_automatic_phase_objection(1)

--- a/ip_env/ip_item.py
+++ b/ip_env/ip_item.py
@@ -1,3 +1,6 @@
+from abc import abstractmethod
+
+
 from uvm.seq.uvm_sequence_item import UVMSequenceItem
 from uvm.macros import (
     uvm_object_utils_begin,
@@ -17,11 +20,13 @@ class ip_item(UVMSequenceItem):
         self.tag = name
         pass
 
-    def convert2string(self):
-        pass
+    @abstractmethod
+    def convert2string(self) -> str:
+        return ""
 
-    def do_compare(self, tr):
-        pass
+    @abstractmethod
+    def do_compare(self, tr) -> bool:
+        return False
 
 
 uvm_object_utils(ip_item)

--- a/ip_env/ip_logger/ip_logger.py
+++ b/ip_env/ip_logger/ip_logger.py
@@ -1,11 +1,14 @@
+import os
+
+from typing import Iterable
+from abc import abstractmethod
+
 from uvm.base.uvm_component import UVMComponent
 from uvm.macros import uvm_component_utils
 from uvm.tlm1.uvm_analysis_port import UVMAnalysisImp
 from uvm.macros import uvm_component_utils, uvm_fatal, uvm_info
 from uvm.base.uvm_object_globals import UVM_HIGH, UVM_LOW
 from uvm.base.uvm_config_db import UVMConfigDb
-import os
-import cocotb
 from tabulate import tabulate
 from EF_UVM.ip_env.ip_item import ip_item
 
@@ -61,7 +64,8 @@ class ip_logger(UVMComponent):
         )
         return row_header + "\n" + row
 
-    def logger_formatter(self, transaction):
+    @abstractmethod
+    def logger_formatter(self, transaction) -> Iterable:
         pass
 
 

--- a/ref_model/ref_model.py
+++ b/ref_model/ref_model.py
@@ -42,7 +42,7 @@ class ref_model(UVMComponent):
         else:
             self.regs = arr[0]
 
-    def user_write_bus(self, tr):
+    def write_bus(self, tr):
         uvm_info(self.tag, " write: " + tr.convert2string(), UVM_HIGH)
         pass
 

--- a/ref_model/ref_model.py
+++ b/ref_model/ref_model.py
@@ -42,7 +42,7 @@ class ref_model(UVMComponent):
         else:
             self.regs = arr[0]
 
-    def write_bus(self, tr):
+    def user_write_bus(self, tr):
         uvm_info(self.tag, " write: " + tr.convert2string(), UVM_HIGH)
         pass
 

--- a/scoreboard.py
+++ b/scoreboard.py
@@ -162,7 +162,6 @@ uvm_component_utils(scoreboard)
 
 
 class QueueUpdated(Queue):
-
     def __init__(self, maxsize=0):
         super().__init__(maxsize=maxsize)
 


### PR DESCRIPTION
\+ Add `bus_env.bus_regs.write_reg_value_after`
\+ Add `bus_env.bus_regs.read_reg_value_delayed`
\+ Add `abstractmethod` decorator and return type hints to the following methods:
- `ip_env.ip_item.convert2string`
- `ip_env.ip_item.do_compare`
- `ip_env.ip_logger.logger_formatter`
